### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ pydantic
 pymailtm
 Levenshtein
 retrying
-mailgw_temporary_email
 pycryptodome
 random-password-generator
 numpy>=1.22.2 # pinned to avoid a vulnerability


### PR DESCRIPTION
mailgw_temporary_email - removed because it causes an error when launched and the launch stops